### PR TITLE
Add support for node.js 14

### DIFF
--- a/msi-keyboard-CLI.js
+++ b/msi-keyboard-CLI.js
@@ -219,7 +219,7 @@ function exit (code, keepRunning) {
 }
 
 // write current PID
-fs.writeFileSync (tmpPidFile, process.pid);
+fs.writeFileSync (tmpPidFile, process.pid.toString());
 
 // Help Section
 if (argv.h || argv.help)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msi-keyboard-cli",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Give a command line interface to manage your MSI keyboard backlight leds",
   "preferGlobal": "true",
   "bin": {


### PR DESCRIPTION
Fixed issue with node.js 14 where the `data` argument of `writeFileSync` can no longer be a number.